### PR TITLE
Missing line break between `index` in initializer block

### DIFF
--- a/exposed-gradle-plugin/plugin-build/exposed-code-generator/src/main/kotlin/org/jetbrains/exposed/gradle/builders/TableBuilder.kt
+++ b/exposed-gradle-plugin/plugin-build/exposed-code-generator/src/main/kotlin/org/jetbrains/exposed/gradle/builders/TableBuilder.kt
@@ -133,9 +133,9 @@ class TableBuilder(
                 val indexType = indexTypeName[index.indexType]
                 val indexTypeString = if (indexType != null) ", indexType = \"$indexType\"" else ""
                 if (index.isUnique) {
-                    add("%M(%S, ${columns.joinToString(", ")}$indexTypeString)", MemberName("", "uniqueIndex"), name)
+                    addStatement("%M(%S, ${columns.joinToString(", ")}$indexTypeString)", MemberName("", "uniqueIndex"), name)
                 } else {
-                    add("%M(%S, false, ${columns.joinToString(", ")}$indexTypeString)", MemberName("", "index"), name)
+                    addStatement("%M(%S, false, ${columns.joinToString(", ")}$indexTypeString)", MemberName("", "index"), name)
                 }
             }
         })

--- a/exposed-gradle-plugin/plugin-build/exposed-code-generator/src/test/kotlin/org/jetbrains/exposed/gradle/ExposedCodeGeneratorTest.kt
+++ b/exposed-gradle-plugin/plugin-build/exposed-code-generator/src/test/kotlin/org/jetbrains/exposed/gradle/ExposedCodeGeneratorTest.kt
@@ -219,9 +219,12 @@ class ExposedCodeGeneratorTest : ExposedCodeGeneratorFromTablesTest() {
             checkColumnProperty("c1", "c1", IntegerColumnType())
             checkColumnProperty("c2", "c2", TextColumnType())
             checkColumnProperty("c3", "c3", IntegerColumnType())
+            checkColumnProperty("c4", "c4", IntegerColumnType())
+            checkColumnProperty("c5", "c5", IntegerColumnType())
         }, excludedDbList = listOf(TestDB.H2, TestDB.H2_MYSQL), indexes = listOf(
                 CompilationResultChecker.IndexWrapper("custom_index_name", false, setOf("c1", "c3")),
-                CompilationResultChecker.IndexWrapper("custom_unique_index_name", true, setOf("c3"))
+                CompilationResultChecker.IndexWrapper("custom_unique_index_name", true, setOf("c3")),
+                CompilationResultChecker.IndexWrapper("custom_index_2_name", false, setOf("c4", "c5")),
         ))
     }
 
@@ -241,9 +244,12 @@ class ExposedCodeGeneratorTest : ExposedCodeGeneratorFromTablesTest() {
         testTableByCompilation(UniqueIndexTable, {
             checkColumnProperty("c1", "c1", IntegerColumnType())
             checkColumnProperty("c2", "c2", IntegerColumnType())
+            checkColumnProperty("c3", "c3", IntegerColumnType())
+            checkColumnProperty("c4", "c4", IntegerColumnType())
         }, excludedDbList = listOf(TestDB.H2, TestDB.H2_MYSQL), indexes = listOf(
                 CompilationResultChecker.IndexWrapper("idx1", true, setOf("c2")),
-                CompilationResultChecker.IndexWrapper("idx2", true, setOf("c1", "c2"))
+                CompilationResultChecker.IndexWrapper("idx2", true, setOf("c1", "c2")),
+                CompilationResultChecker.IndexWrapper("idx3", true, setOf("c3", "c4")),
         ))
     }
 

--- a/exposed-gradle-plugin/plugin-build/exposed-code-generator/src/test/kotlin/org/jetbrains/exposed/gradle/databases/IndexTables.kt
+++ b/exposed-gradle-plugin/plugin-build/exposed-code-generator/src/test/kotlin/org/jetbrains/exposed/gradle/databases/IndexTables.kt
@@ -23,16 +23,22 @@ object MultiColumnIndexTable : Table("multi_column_index_table") {
     val c1: Column<Int> = integer("c1")
     val c2: Column<String> = text("c2")
     val c3: Column<Int> = integer("c3").uniqueIndex("custom_unique_index_name")
+    val c4: Column<Int> = integer("c4")
+    val c5: Column<Int> = integer("c5")
     init {
         index("custom_index_name", false, c1, c3)
+        index("custom_index_2_name", false, c4, c5)
     }
 }
 
 object UniqueIndexTable : Table("unique_index_table") {
     val c1: Column<Int> = integer("c1")
     val c2: Column<Int> = integer("c2").uniqueIndex("idx1")
+    val c3: Column<Int> = integer("c3")
+    val c4: Column<Int> = integer("c4")
     init {
         uniqueIndex("idx2", c1, c2)
+        uniqueIndex("idx3", c3, c4)
     }
 }
 


### PR DESCRIPTION
```sql
CREATE TABLE test
(
    id BIGSERIAL NOT NULL PRIMARY KEY,
    c1 INT NOT NULL,
    c2 INT NOT NULL,
    c3 INT NOT NULL,
    c4 INT NOT NULL
);
CREATE INDEX test_index_1 ON test (c1, c2);
CREATE INDEX test_index_2 ON test (c3, c4);
```

Expected:
```kotlin
object Test : LongIdTable("test", "id") {
  val c1: Column<Int> = integer("c1")

  val c2: Column<Int> = integer("c2")

  val c3: Column<Int> = integer("c3")

  val c4: Column<Int> = integer("c4")

  init {
    index("test_index_1", false, c1, c2)
    index("test_index_2", false, c3, c4)
  }
}
```

Actual:
```kotlin
object Test : LongIdTable("test", "id") {
  val c1: Column<Int> = integer("c1")

  val c2: Column<Int> = integer("c2")

  val c3: Column<Int> = integer("c3")

  val c4: Column<Int> = integer("c4")

  init {
    index("test_index_1", false, c1, c2)index("test_index_2", false, c3, c4)}
}
```