### PR TITLE
Fixed Primary key import causing compile errors on code gen

### DIFF
--- a/exposed-gradle-plugin/plugin-build/exposed-code-generator/src/main/kotlin/org/jetbrains/exposed/gradle/builders/TableBuilder.kt
+++ b/exposed-gradle-plugin/plugin-build/exposed-code-generator/src/main/kotlin/org/jetbrains/exposed/gradle/builders/TableBuilder.kt
@@ -105,7 +105,7 @@ class TableBuilder(
                     ?: throw ReferencedColumnNotFoundException("Primary key column ${it.fullName} not found.")
         }
         val primaryKey =
-                PropertySpec.builder("primaryKey", ClassName("", "PrimaryKey"), KModifier.OVERRIDE)
+                PropertySpec.builder("primaryKey", ClassName("org.jetbrains.exposed.sql", "Table").nestedClass("PrimaryKey"), KModifier.OVERRIDE)
                         .initializer(CodeBlock.of("%M(${primaryKeys.joinToString(", ")})", MemberName("", "PrimaryKey")))
                         .build()
         builder.addProperty(primaryKey)


### PR DESCRIPTION
While this does change the type to be Table.PrimaryKey, it does solve the issue presented with using Flywheel as indicated in #8 